### PR TITLE
Add containers and format page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,38 @@
   </head>
 
   <body>
+    <!-- Page Header -->
     <div class="centre">
       <h1>Hack Club CSS Theme</h1>
-      <a class="pill pill2" style="margin-right: 8px" href="https://github.com/hackclub/css-theme" target="_blank">GitHub</a>
-      <a class="pill" href="/standard.css"  style="margin-right: 8px">Base Theme</a>
-      <a class="pill pill2" href="/fonts.css" target="_blank">Fonts (HQ-only)</a>
+      <a
+        class="pill pill2"
+        style="margin-right: 8px"
+        href="https://github.com/hackclub/css-theme"
+        target="_blank"
+        >GitHub</a
+      >
+      <a class="pill" href="/standard.css" style="margin-right: 8px"
+        >Base Theme</a
+      >
+      <a class="pill pill2" href="/fonts.css" target="_blank"
+        >Fonts (HQ-only)</a
+      >
     </div>
-    <div class="container">
+
+    <main class="container">
+      <!-- Containers-->
+      <h2 class="leading-loose">Containers</h2>
+      <div class="container">
+        <div class="container container-demo-styles text-center">
+          .container
+        </div>
+        <div class="wide container-demo-styles text-center">.wide</div>
+        <div class="copy container-demo-styles text-center">.copy</div>
+        <div class="narrow container-demo-styles text-center">.narrow</div>
+      </div>
+
+      <!-- Text -->
+      <h2 class="leading-loose">Text</h2>
       <a class="line-break"></a>
       <div class="box">
         <h1>Ultratitle (h1)</h1>
@@ -25,11 +50,16 @@
         <h5>Caption (h5)</h5>
         <p>paragraph</p>
       </div>
-      <br />
+
+      <!-- Buttons -->
+      <h2 class="leading-loose">Buttons</h2>
       <button class="button-fill">.button-fill</button>
       <button class="lg-button-fill">.lg-button-fill</button>
       <button class="button-outline">.button-outline</button>
       <button class="lg-button-outline">.lg-button-outline</button>
+
+      <!-- Colors -->
+      <h2 class="leading-loose">Colors</h2>
       <div class="all-color-box">
         <div class="color-box" style="background-color: var(--darker)">
           <p>var(--darker)</p>
@@ -105,6 +135,6 @@
         </div>
       </div>
       <p class="footer"></p>
-    </div>
+    </main>
   </body>
 </html>

--- a/standard.css
+++ b/standard.css
@@ -1,6 +1,7 @@
 html,
 body {
-  font-family: "Phantom Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: "Phantom Sans", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, sans-serif;
   margin: none;
   padding: none;
   font-weight: 400;
@@ -55,10 +56,6 @@ body {
 
 /* boxes */
 
-.container {
-  margin: 3% 8% 3% 8%;
-}
-
 .box {
   margin: 0;
   background-color: #e0e6ed;
@@ -66,6 +63,34 @@ body {
   border-radius: 12px;
   word-wrap: break-word;
   overflow-x: auto;
+}
+
+/* Containers */
+
+@media screen and (min-width: 48em) {
+  .container {
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .wide {
+    max-width: 1536px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .copy {
+    max-width: 768px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .narrow {
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 /*colors and shadows! */
@@ -98,9 +123,11 @@ body {
   --secondary: #8492a6;
   --accent: #5bc0de;
   --text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 2px 4px rgba(0, 0, 0, 0.125);
-  --small-shadow: 0 1px 2px rgba(0, 0, 0, 0.0625), 0 2px 4px rgba(0, 0, 0, 0.0625);
+  --small-shadow: 0 1px 2px rgba(0, 0, 0, 0.0625),
+    0 2px 4px rgba(0, 0, 0, 0.0625);
   --card-shadow: 0 4px 8px rgba(0, 0, 0, 0.125);
-  --elevated-shadow: 0 1px 2px rgba(0, 0, 0, 0.0625), 0 8px 12px rgba(0, 0, 0, 0.125);
+  --elevated-shadow: 0 1px 2px rgba(0, 0, 0, 0.0625),
+    0 8px 12px rgba(0, 0, 0, 0.125);
 }
 
 /* buttons */

--- a/style.css
+++ b/style.css
@@ -20,6 +20,19 @@
   margin-top: 43%;
 }
 
+/* Container examples */
+
+.container-demo-styles {
+  border-style: dashed;
+  border-color: var(--smoke);
+  border-radius: 5px;
+  border-width: 3px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
 /* additional styling */
 
 .centre {
@@ -57,11 +70,44 @@
   box-shadow: var(--card-shadow);
   text-decoration: none;
 }
-.pill:hover{
-    transform: rotate(2deg);
-    box-shadow: var(--elevated-shadow);
+.pill:hover {
+  transform: rotate(2deg);
+  box-shadow: var(--elevated-shadow);
 }
-.pill2:hover{
-    transform: rotate(-2deg);
-    box-shadow: var(--elevated-shadow);
+.pill2:hover {
+  transform: rotate(-2deg);
+  box-shadow: var(--elevated-shadow);
+}
+
+/* utility classes */
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.flex-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.leading-loose {
+  line-height: 2;
 }


### PR DESCRIPTION
- Adds classes for containers (also fixes the problem where the page doesn't work well on large screens)
- Adds headings to corresponding sections on the page

prev: 
<img width="500" alt="page on large screens" src="https://user-images.githubusercontent.com/72365100/142280115-94b2a283-0572-4a61-b140-add0cd4415cd.png">

now:
<img width="1537" alt="Screen Shot 2021-11-17 at 12 51 01 PM" src="https://user-images.githubusercontent.com/72365100/142280434-75c07a8a-fcb8-479d-a4b0-e152b7450125.png">


